### PR TITLE
Add basic 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ We are using [Swoosh](https://hexdocs.pm/swoosh/Swoosh.html) [not yet configured
 
 To see mailbox in dev go to: `http://localhost:4000/dev/mailbox/`
 or curl: `curl http://localhost:4000/dev/mailbox/json`
+
+# Error Pages
+
+In `maria/config/dev.exs` set `debug_errors: false` if you want to be able to debug error pages.

--- a/lib/maria_web/components/helper_components.ex
+++ b/lib/maria_web/components/helper_components.ex
@@ -173,11 +173,12 @@ defmodule MariaWeb.HelperComponents do
     """
   end
 
+  attr :color, :string, default: "text-brand"
   def page_header(assigns) do
     ~H"""
     <header class="px-4 py-6 sm:px-6 lg:px-8 xl:px-28 bg-white sticky top-0 z-[60]">
       <div class="mx-auto max-w-xl lg:mx-auto">
-        <a  href="/"  class="flex md:justify-center text-4xl font-racing font-semibold text-brand bg-white uppercase">
+        <a  href="/"  class={[@color, "flex md:justify-center text-4xl font-racing font-semibold text-brand bg-white uppercase"]}>
           carras.co
         </a>
       </div>

--- a/lib/maria_web/controllers/error_html.ex
+++ b/lib/maria_web/controllers/error_html.ex
@@ -8,7 +8,7 @@ defmodule MariaWeb.ErrorHTML do
   #   * lib/maria_web/controllers/error_html/404.html.heex
   #   * lib/maria_web/controllers/error_html/500.html.heex
   #
-  # embed_templates "error_html/*"
+  embed_templates "error_html/*"
 
   # The default is to render a plain text page based on
   # the template name. For example, "404.html" becomes

--- a/lib/maria_web/controllers/error_html/404.html.heex
+++ b/lib/maria_web/controllers/error_html/404.html.heex
@@ -13,20 +13,55 @@
     <script defer type="text/javascript" src="/js/app.js"></script>
   </head>
   <body>
-<div class="sm:min-h-screen bg-brand">
-  <.page_header />
-  <div class="px-6 py-36 sm:py-40 sm:px-8 md:py-44 lg:px-8 xl:py-52 xl:px-28 bg-brand">
-    <div class="mx-auto text-white">
-      <p class="leading-none mt-4 text-[3.5rem] flex justify-center font-semibold tracking-tighter">
-        404 <span class="inline-block animate-wave hover:animate-waving cursor-grab">💔</span>
-      </p>
-      <div class="mt-10 flex justify-center text-center">
-        <p class="font-head font-medium w-[460px] text-2xl">
-          The page you are looking for is not here, go back <.link_hover class="italic" href="/">home</.link_hover>.
-        </p>
+    <div class="min-h-screen bg-skin">
+      <.page_header color="text-blood"/>
+      <div class="px-6 py-36 sm:py-40 sm:px-8 md:py-44 lg:px-8 xl:py-52 xl:px-28">
+            <div class="mx-auto text-white">
+          <p class="leading-none mt-4 text-[3.5rem] flex justify-center font-semibold tracking-tighter">
+            404 <span class="inline-block animate-wave hover:animate-waving cursor-grab pl-4">💔</span>
+          </p>
+          <div class="mt-10 flex justify-center text-center">
+            <p class="font-head font-medium w-[460px] text-2xl">
+              The page you are looking for is not here, go back <.link_hover class="italic" href="/">home</.link_hover>.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</div>
+    <div class="fixed bottom-0 px-6 py-6 sm:px-8 lg:px-8 xl:px-28 flex justify-between bg-white w-full">
+      <div class="">
+        <div class="grid grid-cols-4 gap-y-4 gap-x-4 text-ml leading-6 text-brand  capitalize font-semibold">
+          <div>
+            <a
+              href="https://twitter.com/kostspielig"
+              target="_blank"
+              class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-blood lowercase"
+            >🐦</a>
+          </div>
+          <div>
+            <a
+              href="https://instagram.com/kostspielig"
+              target="_blank"
+              class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-blood lowercase"
+            >📸</a>
+          </div>
+          <div>
+            <a
+              href="https://github.com/kostspielig"
+              target="_blank"
+              class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-blood lowercase"
+            >🐈</a>
+          </div>
+          <div>
+            <a
+              href="https://www.tiktok.com/@kstsplg"
+              target="_blank"
+              class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-blood lowercase"
+            >🎥</a>
+          </div>
+        </div>
+      </div>
+      <div class="font-head">© Maria Carrasco</div>
+    </div>
   </body>
 </html>

--- a/lib/maria_web/controllers/error_html/404.html.heex
+++ b/lib/maria_web/controllers/error_html/404.html.heex
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" style="scrollbar-gutter: stable;">
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>carras.co ☢️</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦪</text></svg>">   <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Gloock&family=Racing+Sans+One&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/app.css"/>
+    <meta name="theme-color" content="#3aadec" />
+    <meta name="description" content="Personal recommendations by Maria Carrasco" />
+    <script defer type="text/javascript" src="/js/app.js"></script>
+  </head>
+  <body>
+<div class="sm:min-h-screen bg-brand">
+  <.page_header />
+  <div class="px-6 py-36 sm:py-40 sm:px-8 md:py-44 lg:px-8 xl:py-52 xl:px-28 bg-brand">
+    <div class="mx-auto text-white">
+      <p class="leading-none mt-4 text-[3.5rem] flex justify-center font-semibold tracking-tighter">
+        404 <span class="inline-block animate-wave hover:animate-waving cursor-grab">💔</span>
+      </p>
+      <div class="mt-10 flex justify-center text-center">
+        <p class="font-head font-medium w-[460px] text-2xl">
+          The page you are looking for is not here, go back <.link_hover class="italic" href="/">home</.link_hover>.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+  </body>
+</html>


### PR DESCRIPTION
We did not render our 404.html.heex template through our application layout, even though we want our error page to have the look and feel of the rest of our site. This is to avoid circular errors. For example, what happens if our application failed due to an error in the layout? Attempting to render the layout again will just trigger another error. So ideally we want to minimize the amount of dependencies and logic in our error templates, sharing only what is necessary.


![scrn-2023-07-26-17-31-51](https://github.com/kostspielig/maria/assets/3260147/9ab03e54-d8ce-46dd-bcdb-14d5fa9ae68c )
