### PR TITLE
Improve links in touch devices

### DIFF
--- a/lib/maria_web/components/helper_components.ex
+++ b/lib/maria_web/components/helper_components.ex
@@ -51,7 +51,7 @@ defmodule MariaWeb.HelperComponents do
     ~H"""
     <div class="mt-2"><span class="font-racing">➭ <%= render_slot(@inner_block) %></span> <%= @icon %>
       <a href={"#{@href}"} target="_blank" class="group">
-          <span class="bg-left-bottom bg-gradient-to-r from-green to-green bg-[length:0%_33%] bg-no-repeat group-hover:bg-[length:100%_33%] transition-all duration-500 ease-out">
+          <span class="italic bg-left-bottom bg-gradient-to-r from-green to-green bg-[length:0%_33%] bg-no-repeat [@media(hover:none)]:bg-[length:100%_33%] group-hover:bg-[length:100%_33%] transition-all duration-500 ease-out">
         <%= extract_host(@href) %>
       </span>
       </a>
@@ -68,7 +68,7 @@ defmodule MariaWeb.HelperComponents do
   def link_hover(assigns) do
     ~H"""
     <a class={["group transition-all duration-300 ease-in-out", @class]} href={@href} target={@target}>
-      <span class={"bg-left-bottom bg-gradient-to-r from-#{@color} to-#{@color} bg-[length:0%_33%] bg-no-repeat group-hover:bg-[length:100%_33%] transition-all duration-500 ease-out"}>
+      <span class={"bg-left-bottom bg-gradient-to-r from-#{@color} to-#{@color} bg-[length:0%_33%] bg-no-repeat [@media(hover:none)]:bg-[length:100%_33%] group-hover:bg-[length:100%_33%] transition-all duration-500 ease-out"}>
         <%= render_slot(@inner_block) %>
       </span>
     </a>


### PR DESCRIPTION
Addresses #17 


We add a pseudo class for a custom media query in tailwind `[@media(hover:none)]:`. This class will target devices where the primary input mechanism system  cannot hover over elements with ease or they can but not easily (for example a long touch is performed to emulate the hover) or there is no primary input mechanism at all


![localhost_4000_](https://github.com/kostspielig/maria/assets/3260147/fb28d5b3-45cc-4361-9b1f-29d8f3ac4180)
