### PR TITLE
Fix wine image display.

### DIFF
--- a/lib/maria_web/live/wine_live/show.html.heex
+++ b/lib/maria_web/live/wine_live/show.html.heex
@@ -48,7 +48,7 @@
       </:other>
     </.header>
     <div class="my-6 md:mt-0 max-w-screen-lg mx-auto">
-      <div class="max-h-[600px] min-w-[300px]"><img class="mx-auto" src={"#{@wine.image}"}></div>
+      <div><img class="mx-auto max-h-[600px] min-w-[300px]" src={"#{@wine.image}"}></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description 🥠

If the image was bigger it overflowed the div size requirements from the parent

<!-- Please do not leave this blank 🫶 ~~

This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Screenshots/Recordings 🖥️ or QA Instructions 👩‍🏫

![scrn-2023-09-05-17-42-39](https://github.com/kostspielig/maria/assets/3260147/812df823-f66b-4ff8-b988-bcbfbe0ff8f3)
<!-- Visual changes should add screenshots or gif recordings ~~

To add centered images controlling their width use:

<p align="center" width="100%">
 <img width="80%" src="__INSERT_HERE__" /> 
</p>
-->
