### PR TITLE
Fix the bug when creating draft recipes

### DIFF
--- a/test/maria/recipes_test.exs
+++ b/test/maria/recipes_test.exs
@@ -85,5 +85,18 @@ defmodule Maria.RecipesTest do
       recipe = recipe_fixture()
       assert %Ecto.Changeset{} = Recipes.change_recipe(recipe)
     end
+
+    test "related/1 returns a list of related recipes" do
+      recipe = recipe_fixture()
+      relatedRecipe = recipe_fixture(%{ tags: "option1", title: "Related Recipe"})
+
+      assert hd(Recipes.related(recipe, 1)).title  == relatedRecipe.title
+    end
+
+    test "related/1 returns an empty list if tags is nil (in drafts it can be!)" do
+      recipe = recipe_fixture(%{ tags: nil, is_draft: true})
+
+      assert Recipes.related(recipe, 1)  == []
+    end
   end
 end


### PR DESCRIPTION


## Description 🥠

Allow to have draft recipes without tags and not show a related recipes used to break the interface as the tags were not there.


<!-- Please do not leave this blank 🫶 ~~

This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## GIF [🔭](https://giphy.com/)


<!-- Please select a GIF of your liking ~~

It does not need to be related to this PR's content but it can.
-->

<p align="center" width="100%">
 <img with="700px" src="https://media.giphy.com/media/FIDUw92IdQ5xUqGQhH/giphy.gif" /> 
</p>


<!-- ➡ For WIP PRs, please 🙏 use the Draft PR feature ~~
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
